### PR TITLE
fix: react and react-dom peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Payload Admin Bar
 
-An admin bar for React apps using Payload CMS.
+An admin bar for React apps using [Payload](https://github.com/payloadcms/payload) as a headless CMS.
 
 ### Installation
 
@@ -13,7 +13,7 @@ $ yarn add payload-admin-bar
 ### Basic Usage
 
 ```jsx
-import { PayloadAdminBar } from 'payload-admin-bar';
+import { PayloadAdminBar } from "payload-admin-bar";
 
 export const App = () => {
   return (
@@ -22,8 +22,8 @@ export const App = () => {
       collection="pages"
       id="12345"
     />
-  )
-}
+  );
+};
 ```
 
 Checks for authentication with Payload CMS by hitting the [`/me`](https://payloadcms.com/docs/authentication/operations#me) route. If authenticated, renders an admin bar with simple controls to do the following:
@@ -98,26 +98,27 @@ export const App = (appProps) => {
 ```
 
 ### Props
-Property | Type | Required | Default | Description
---- | --- | --- | ---  | ---
-cmsURL | `string` | true | `http://localhost:8000` | `serverURL` as defined in your [Payload config](https://payloadcms.com/docs/configuration/overview#options)
-adminPath | `string` | false | /admin | `routes` as defined in your [Payload config](https://payloadcms.com/docs/configuration/overview#options)
-apiPath | `string` | false | /api | `routes` as defined in your [Payload config](https://payloadcms.com/docs/configuration/overview#options)
-collection | `string` | true | undefined | Slug of your [collection](https://payloadcms.com/docs/configuration/collections)
-collectionLabels | `{ singular?: string, plural?: string }` | false | undefined | Labels of your [collection](https://payloadcms.com/docs/configuration/collections)
-id | `string` | true | undefined | id of the document
-logo | `ReactElement` | false | undefined | Custom logo
-classNames | `{ logo?: string, user?: string, controls?: string, create?: string, logout?: string, edit?: string, preview?: string }` | false | undefined | Custom class names, one for each rendered element
-logoProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-userProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-divProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-createProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-logoutProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-editProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-previewProps | `{[key: string]?: unknown}` | false | undefined | Custom props
-style | `CSSProperties` | false | undefined | Custom inline style
-unstyled | `boolean` | false | undefined | If true, renders no inline style
-onAuthChange | `(user: PayloadMeUser) => void` | false | undefined | Fired on each auth change
-devMode | `boolean` | false | undefined | If true, fakes authentication (useful when dealing with [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite))
-preview | `boolean` | false | undefined | If true, renders an exit button with your `onPreviewExit` handler)
-onPreviewExit | `function` | false | undefined | Callback for the preview button `onClick` event)
+
+| Property         | Type                                                                                                                     | Required | Default                 | Description                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------ | -------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| cmsURL           | `string`                                                                                                                 | true     | `http://localhost:8000` | `serverURL` as defined in your [Payload config](https://payloadcms.com/docs/configuration/overview#options)                                                |
+| adminPath        | `string`                                                                                                                 | false    | /admin                  | `routes` as defined in your [Payload config](https://payloadcms.com/docs/configuration/overview#options)                                                   |
+| apiPath          | `string`                                                                                                                 | false    | /api                    | `routes` as defined in your [Payload config](https://payloadcms.com/docs/configuration/overview#options)                                                   |
+| collection       | `string`                                                                                                                 | true     | undefined               | Slug of your [collection](https://payloadcms.com/docs/configuration/collections)                                                                           |
+| collectionLabels | `{ singular?: string, plural?: string }`                                                                                 | false    | undefined               | Labels of your [collection](https://payloadcms.com/docs/configuration/collections)                                                                         |
+| id               | `string`                                                                                                                 | true     | undefined               | id of the document                                                                                                                                         |
+| logo             | `ReactElement`                                                                                                           | false    | undefined               | Custom logo                                                                                                                                                |
+| classNames       | `{ logo?: string, user?: string, controls?: string, create?: string, logout?: string, edit?: string, preview?: string }` | false    | undefined               | Custom class names, one for each rendered element                                                                                                          |
+| logoProps        | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| userProps        | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| divProps         | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| createProps      | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| logoutProps      | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| editProps        | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| previewProps     | `{[key: string]?: unknown}`                                                                                              | false    | undefined               | Custom props                                                                                                                                               |
+| style            | `CSSProperties`                                                                                                          | false    | undefined               | Custom inline style                                                                                                                                        |
+| unstyled         | `boolean`                                                                                                                | false    | undefined               | If true, renders no inline style                                                                                                                           |
+| onAuthChange     | `(user: PayloadMeUser) => void`                                                                                          | false    | undefined               | Fired on each auth change                                                                                                                                  |
+| devMode          | `boolean`                                                                                                                | false    | undefined               | If true, fakes authentication (useful when dealing with [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)) |
+| preview          | `boolean`                                                                                                                | false    | undefined               | If true, renders an exit button with your `onPreviewExit` handler)                                                                                         |
+| onPreviewExit    | `function`                                                                                                               | false    | undefined               | Callback for the preview button `onClick` event)                                                                                                           |

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint": "eslint ."
   },
   "peerDependencies": {
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",


### PR DESCRIPTION
Fixes React peer dependency conflicts caused by only specifying `react` and `react-dom` versions `^17.0.0`. Now allows `^16.8.0` and `^18.0.0`.